### PR TITLE
feat (feature): Find matching instances of document

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ import express from 'express';
 import expressValidator from 'express-validator';
 import { createUser, loginUser, allUser, findUser,
 updateUser, deleteUser } from './server/routes/user';
-import { createDocument } from './server/routes/documents';
+import { createDocument, getAllDocument } from './server/routes/documents';
 import authentication from './server/middleware/authentication';
 
 const server = express();
@@ -29,7 +29,8 @@ apiRoutes
 .delete('/users/:id', authentication.verifyToken, deleteUser);
 
 apiRoutes
-.post('/documents', authentication.verifyToken, createDocument);
+.post('/documents', authentication.verifyToken, createDocument)
+.get('/documents', authentication.verifyToken, getAllDocument);
 
 server.listen(3004, () => {
 });

--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -33,6 +33,39 @@ const createDocument = (request, response) => {
 };
 
 
+const getAllDocument = (request, response) => {
+  const isAdmin = RegExp('admin', 'gi').test(request.decoded.data.roleType);
+  let query;
+  if (isAdmin) {
+    query = { order: [['createdAt', 'DESC']],
+    };
+  } else {
+    query = { order: [['createdAt', 'DESC']],
+      where: {
+        $or: [
+          { userId: request.decoded.data.userId },
+          { access: 'public' }
+        ]
+      }
+    };
+  }
+  models.Document.findAndCountAll(query)
+  .then((document) => {
+    response.status(200).json({
+      documentCount: document.count,
+      message: 'successful',
+      document: document.rows,
+    });
+  })
+  .catch((error) => {
+    response.status(400).json({
+      message: 'An error occured retrieving documents',
+      data: error,
+    });
+  });
+};
+
 module.exports = {
   createDocument,
+  getAllDocument,
 };


### PR DESCRIPTION
#### What does this PR do?
 - Get matching instances of document

#### Description of Task to be completed?
End Point:  `[GET]/documents/`
As a user sending a GET request to `/documents/` should return the available documents in the database.

#### How should this be manually tested?
 - send a GET request to `localhost:3004/api/v1/documents` which would return a JSON object showing the number of available document and the document details

#### Any background context you want to provide?
 - none

#### What are the relevant pivotal tracker stories?
 - Get matching instances of document  #149667379

#### Screenshots (if appropriate)
 - none

#### Questions: