### PR TITLE
feat (feature): Pagination for docs

### DIFF
--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -34,13 +34,18 @@ const createDocument = (request, response) => {
 
 
 const getAllDocument = (request, response) => {
+  const paginate = helper.paginate(request);
   const isAdmin = RegExp('admin', 'gi').test(request.decoded.data.roleType);
   let query;
   if (isAdmin) {
     query = { order: [['createdAt', 'DESC']],
+      offset: paginate[0],
+      limit: paginate[1],
     };
   } else {
     query = { order: [['createdAt', 'DESC']],
+      offset: paginate[0],
+      limit: paginate[1],
       where: {
         $or: [
           { userId: request.decoded.data.userId },


### PR DESCRIPTION
#### What does this PR do?
 - Pagination for docs

#### Description of Task to be completed?
End Point:  `[GET] /documents/?limit={integer}&offset={integer}` should display results based on the limit and offset specified.

#### How should this be manually tested?
 - send a GET request to `localhost:3004/api/v1/documents/?limit=2&offset=2` where limit is the number of document to display at an given time and offset the number of documents to skip/bypass.

#### Any background context you want to provide?
 - none

#### What are the relevant pivotal tracker stories?
 -  Pagination for docs  #149669605

#### Screenshots (if appropriate)
 - none

#### Questions: