### PR TITLE
feat (feature): Find all documents belonging to the user

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,8 +3,8 @@ import express from 'express';
 import expressValidator from 'express-validator';
 import { createUser, loginUser, allUser, findUser,
 updateUser, deleteUser } from './server/routes/user';
-import { createDocument, getAllDocument, updateDocument
- } from './server/routes/documents';
+import { createDocument, getAllDocument, updateDocument,
+ getDocumentByUserId } from './server/routes/documents';
 import authentication from './server/middleware/authentication';
 
 const server = express();
@@ -32,7 +32,8 @@ apiRoutes
 apiRoutes
 .post('/documents', authentication.verifyToken, createDocument)
 .get('/documents', authentication.verifyToken, getAllDocument)
-.put('/documents/:id', authentication.verifyToken, updateDocument);
+.put('/documents/:id', authentication.verifyToken, updateDocument)
+.get('/users/:id/documents', authentication.verifyToken, getDocumentByUserId);
 
 server.listen(3004, () => {
 });

--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -137,9 +137,42 @@ const deleteDocument = (request, response) => {
   });
 };
 
+const getDocumentByUserId = (request, response) => {
+  const userId = request.params.id;
+  const isAdmin = RegExp('admin', 'gi').test(request.decoded.data.roleType);
+  let query;
+  if (isAdmin) {
+    query = { where: { userId } };
+  } else {
+    query = { where: { userId, access: 'public' } };
+  }
+  models.Document.findAll(query)
+  .then((document) => {
+    if (!document.length === 0) {
+      response.status(200).json({
+        message: 'successful',
+        document
+      });
+    } else {
+      response.status(401).json({
+        message: 'You do not have access to view the available documents',
+        document
+      });
+    }
+  })
+  .catch((error) => {
+    response.status(400).json({
+      message: 'An error occured! Document could not be deleted',
+      error,
+    });
+  });
+};
+
+
 module.exports = {
   createDocument,
   getAllDocument,
   updateDocument,
   deleteDocument,
+  getDocumentByUserId,
 };


### PR DESCRIPTION
#### What does this PR do?
 - Find all documents belonging to the user

#### Description of Task to be completed?
 As a user i want to be able search for documents by specifying a userId

#### How should this be manually tested?
 - send a GET request to `localhost:3004/api/v1/users/id/documents` where `id` is the user's ID, this will return all the documents created by the specified user id

#### Any background context you want to provide?
 - none

#### What are the relevant pivotal tracker stories?
 -  Find all documents belonging to the user  #149679177

#### Screenshots (if appropriate)
 - none

#### Questions: